### PR TITLE
Remove warning for number fields on answered field component

### DIFF
--- a/src/components/AnsweredField/AnsweredField.spec.js
+++ b/src/components/AnsweredField/AnsweredField.spec.js
@@ -8,4 +8,11 @@ describe('AnsweredField', () => {
     expect(wrapper.find('[data-test="answered-field-value"]').element.value).toBe('Frodo')
     expect(wrapper.find('input').attributes().disabled).toBe('disabled')
   })
+
+  it('renders a disabled input with number values', () => {
+    const wrapper = shallowMount(AnsweredField, { propsData: { label: 'Age', value: 50 } })
+    expect(wrapper.find('[data-test="answered-field-label"]').text()).toBe('Age')
+    expect(wrapper.find('[data-test="answered-field-value"]').element.value).toBe('50')
+    expect(wrapper.find('input').attributes().disabled).toBe('disabled')
+  })
 })

--- a/src/components/AnsweredField/AnsweredField.vue
+++ b/src/components/AnsweredField/AnsweredField.vue
@@ -18,7 +18,7 @@ export default {
       required: true
     },
     value: {
-      type: String,
+      type: [String, Number],
       required: true
     },
     dataTest: {


### PR DESCRIPTION
### Description
Some warnings were presented during the execution of unit tests on `medical-research` repository. This PR fix the validation problem.
![image](https://github.com/lopes-software/design-system/assets/25910024/24aab8d1-b806-4ff6-abb4-e56e977c2951)
